### PR TITLE
Add backend system info retrieval script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ Duplicate `user` entries are not accepted, and only the first instance of that `
 **Usage**:</br>
 &ensp;`python get_analytics_for_users.py <hub>`
 
+-----
+
+### get_backend_info.py
+**What it does**: Retreives a list of backend system names from either an entire Hub or a specific Project</br>
+**Parameters**:</br>
+&ensp;`<hub>`: Required. The name of your hub.</br>
+&ensp;`<-group>`: Optional. The name of the parent group.</br>
+&ensp;`<-project>`: Optional. The name of the project.</br>
+&ensp;`<--full_data>`: Optional. Prints out the entirety of the backend data.</br>
+**Usage**:</br>
+&ensp;`python get_backend_info.py <hub> <-group> <-project> --full_data`
+
+
 ## How to contribute
 
 Contributions are welcomed as long as the stick to the git-flow: fork this repo, create a local branch named 'feature-XXX'. Commit often. Split it in multiple commits and request a merge to the mainline often. When you contribute code, you affirm that the contribution is your original work and that you license the work to the project under the project’s open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project’s open source license and warrant that you have the legal authority to do so.

--- a/get_backend_info.py
+++ b/get_backend_info.py
@@ -1,0 +1,66 @@
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import requests
+import argparse
+import sys
+import json
+from auth import get_access_token
+
+API_URL = "https://api-qcon.quantum-computing.ibm.com/api"
+
+parser = argparse.ArgumentParser(description="Retrieve backend system information from your entire Hub or a specific Project")
+parser.add_argument('hub', type=str, help="The Hub to retreive backend information from")
+parser.add_argument('-group', type=str, help="Name of the group to retrieve backends from")
+parser.add_argument('-project', type=str, help="Name of the project to retrieve backends from")
+parser.add_argument('--full_data', action="store_true", help="Print out the full JSON response for all backend data")
+
+args = parser.parse_args()
+
+hub = args.hub
+group = args.group
+project = args.project
+full_data = args.full_data
+
+access_token = get_access_token()
+headers = {'X-Access-Token': access_token}
+
+# Determine which URL to use- either it is a request for the entire Hub's devices or a specific project's devices.
+# The group and project arguments are mutually inclusive so validate that.
+if group is None and project is None:
+	url = f'{API_URL}/Network/{hub}/devices'
+	s = hub
+elif group is not None and project is not None:
+	url = f'{API_URL}/Network/{hub}/Groups/{group}/Projects/{project}/devices'
+	s = f'{hub} (group: {group} and project: {project})'
+else:
+	sys.exit("You must provide both -group and -project arguments, use the -h parameter for more information")
+
+# Make the API request and handle errors
+try:
+    response = requests.get(url=url, headers=headers)
+    response.raise_for_status()  # Checks if the request returned an error
+except requests.HTTPError as http_err:
+    sys.exit(f"Could not retrieve backend information in {s} due to HTTPError: {http_err}")
+except Exception as err:
+    sys.exit(f"Could not retrieve backend information in {s} due to: {err}")
+
+data = response.json()
+if full_data:
+	print(json.dumps(data, indent=4, sort_keys=True))
+
+# Print a list of backend names only
+backends = []
+for obj in data:
+	# Depending on which API endpoint was hit- the location of the backend_name string differs
+	if 'specificConfiguration' in obj:
+		backends.append(obj['specificConfiguration']['backend_name'])
+	else:
+		backends.append(obj['backend_name'])
+
+print(backends)


### PR DESCRIPTION
closes #2 

-  Adds `get_backend_info.py` script for retrieving backend system information, with two different approaches for doing so.
- Retrieves backend info for the entire Hub, or for a specific project. The arguments provided at the command line determine which URL will be used.
- Updates the readme with basic usage for this script

@kwehden @Matt-Stypulkoski Let me know what you think. Thank you.