### PR TITLE
Update edit_group and edit_project to include new 'priority' api data parameter and update relevant documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ If you experience an `AUTHORIZATION_REQUIRED` error or a `401` status code, doub
 &ensp;`<action>`: Required. Either 'add' or 'remove'.</br>
 &ensp;`<group_name>`: Required. The name of the group being added or removed.</br>
 &ensp;`<group_title>`: Optional. Triggered by the `-t` flag. Only required if adding a group. The title of the group being added.</br>
+&ensp;`<share>`: Optional. Triggered by the `-s` flag. Only required if adding a group. The share of the total group share that this new group will receive. Should be an integer.</br>
+
 **Usage**:</br>
-&ensp;If adding group: `python edit_group.py <hub> add <group_name> -t <group_title>`</br>
+&ensp;If adding group: `python edit_group.py <hub> add <group_name> -t <group_title> -s <share>`</br>
 &ensp;If removing group: `python edit_group.py <hub> remove <group_name>`</br>
 
 -----
@@ -42,8 +44,10 @@ If you experience an `AUTHORIZATION_REQUIRED` error or a `401` status code, doub
 &ensp;`<action>`: Required. Either 'add' or 'remove'.</br>
 &ensp;`<project_name>`: Required. The name of the project you are adding or removing.</br>
 &ensp;`<project_title>`: Optional. Triggered by the `-t` flag. Only required if adding a project. The title of the project being added.</br>
+&ensp;`<share>`: Optional. Triggered by the `-s` flag. Only required if adding a project. The share of the total project share that this new project will receive. Should be an integer.</br>
+
 **Usage**:</br>
-&ensp;If adding project: `python edit_project.py <hub> <group> add <project_name> -t <project_title>` </br>
+&ensp;If adding project: `python edit_project.py <hub> <group> add <project_name> -t <project_title> -s <share>` </br>
 &ensp;If removing project: `python edit_project.py <hub> <group> remove <project_name>`
 
 -----

--- a/edit_group.py
+++ b/edit_group.py
@@ -25,12 +25,15 @@ parser.add_argument('-t', '--title', dest="group_title", nargs=1, type=str,
                     help="Title of group being added. Only required if <action> is set to 'add'. To have multiple "
                          "words in title, format with quotes around the title, or with underscores. "
                          "Example: 'Example Title' or Example_Title")
+parser.add_argument('-s', '--share', dest="share", nargs=1, type=int,
+                    help="Share value set for this group. Only required if <action> is set to 'add'")
 
 args = parser.parse_args()
 
 hub = args.hub
 group_name = args.group_name
 action = args.action
+priority = args.share
 
 if action != 'remove' and action != 'add':
     sys.exit("<action> must be set ot either 'add' or 'remove'")
@@ -50,7 +53,7 @@ if action == "add":
             sys.exit("Group Title must be a string")
 
         # Create Group
-        group_data = {"name": group_name, "title": group_title}
+        group_data = {"name": group_name, "title": group_title, "priority": priority}
         print(f"Adding {group_name} to {hub}")
 
         # POST request to add group

--- a/edit_project.py
+++ b/edit_project.py
@@ -26,12 +26,15 @@ parser.add_argument('-t', '--title', dest="project_title", nargs=1, type=str,
                     help="Title of project being added. Only required if <action> is set to 'add'. To have multiple "
                          "words in title, format with quotes around the title, or with underscores. "
                          "Example: 'Example Title' or Example_Title")
+parser.add_argument('-s', '--share', dest="share", nargs=1, type=int,
+                    help="Share value set for this project. Only required if <action> is set to 'add'")
 
 args = parser.parse_args()
 
 hub = args.hub
 group = args.group
 project_name = args.project_name
+priority = args.share
 action = args.action
 
 if action != 'remove' and action != 'add':
@@ -52,7 +55,7 @@ if action == "add":
             sys.exit("Project Title must be a string")
 
         # Create project
-        project_data = {"name": project_name, "title": project_title}
+        project_data = {"name": project_name, "title": project_title, "priority": priority}
         print(f"Adding {project_name} to {hub}/{group}")
 
         # POST request to add project


### PR DESCRIPTION
The new fair share changes introduced a new data parameter for the endpoints for adding groups and projects. You now need to include a "priority" data value when creating groups and projects. This PR updates the relevant files' api calls to include this data parameter.

The README was also updated to include this new parameter.